### PR TITLE
feat(policy): enforce English-only normative artifacts in templates and docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,23 +2,51 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## Language Policy
+
+All normative specification and task artifacts (PRDs, specifications, implementation plans, issues, task plans) committed to the repository MUST be written in English. Conversational discussions in PRs/issues may occur in other languages, but do not commit non-English content to these artifacts.
+
 ## Project Overview
 
 Spec-Kit is a toolkit for Spec-Driven Development (SDD), a methodology that transforms specifications into executable artifacts that generate working implementations. The project provides templates, scripts, and a CLI tool to facilitate the specification → implementation workflow.
 
 ## Essential Commands
 
-### Building and Testing
+### Testing and Validation
 ```bash
-# No build step required - Python project with direct execution
+# Run all tests
+python -m pytest tests/ -v
+
+# Run specific test files
+python -m pytest tests/test_sdd_validation.py -v
+python -m pytest tests/test_specify_cli.py -v
+
+# Validate SDD structure
+python scripts/sdd/validate_structure.py
+
+# Run semantic checks on SDD documents
+./scripts/sdd/run_semantic_checks.sh
+
+# Lint documentation (requires markdownlint)
+./scripts/sdd/lint_docs.sh
+
 # Test the CLI functionality
 python -m specify_cli check
 
 # Verify Python syntax
 python -m py_compile src/specify_cli/__init__.py
+```
 
-# Make scripts executable if needed
-chmod +x scripts/*.sh
+### Code Quality
+```bash
+# Format Python code
+black src/ tests/ scripts/sdd/*.py --line-length 100
+
+# Lint Python code
+ruff check src/ tests/ scripts/sdd/*.py
+
+# Install development dependencies
+pip install -e ".[dev]"
 ```
 
 ### Running the Project
@@ -97,10 +125,40 @@ Each phase produces artifacts in `specs/NNN-feature-name/`:
 - **Git Branches**: Match feature directory names
 - **Commit Format**: `type: description [TASK-ID]` for traceability
 
+## Directory Structure
+
+```tree
+.
+├── src/specify_cli/        # Main CLI tool implementation
+├── templates/              # SDD document templates
+│   ├── commands/          # AI assistant command definitions
+│   └── *.md              # Specification, plan, and task templates
+├── scripts/               # Automation and workflow scripts
+│   └── sdd/              # SDD validation and linting tools
+├── specs/                 # Feature specifications (NNN-feature-name/)
+├── dev-docs/              # Development documentation
+│   ├── sdd/              # SDD methodology docs (constitution.md, lifecycle.md)
+│   ├── agents/           # AI agent guidelines
+│   ├── git/              # Git workflow documentation
+│   └── cli/              # CLI development docs
+├── tests/                 # Test suite
+└── .github/workflows/     # CI/CD pipelines
+```
+
+## SDD Validation Requirements
+
+- All specifications must not contain `[NEEDS CLARIFICATION]` markers
+- Commit messages must follow format: `type(scope): description [TASK-XXX]`
+- Feature directories must follow `NNN-feature-name` convention
+- Each spec must have corresponding plan.md and tasks.md files
+- Task IDs must be sequential and properly tracked
+
 ## Important Notes
 
 - The project is primarily for macOS/Linux (WSL2 on Windows)
 - Requires `uv` package manager from Astral
-- No traditional test suite - focus is on template generation and workflow automation
+- Python 3.11+ required
 - Scripts assume bash shell availability
 - The CLI checks for AI tool installation but can be bypassed with `--ignore-agent-tools`
+- Tests focus on structure validation rather than unit tests
+- GitHub Actions CI validates SDD compliance on every PR

--- a/WARP.md
+++ b/WARP.md
@@ -1,6 +1,10 @@
 # WARP.md
 
-This file provides guidance to WARP (warp.dev) when working with code in this repository.
+This file provides guidance to Warp Agents (warp.dev) when working with code in this repository.
+
+## Language Policy (English-only Normative Artifacts)
+
+All specification and task artifacts committed to the repository (PRDs, specifications, implementation plans, issues, task plans) MUST be written in English. Conversations with developers may use other languages, but do not commit non-English content for these artifacts.
 
 ## Essential Commands
 

--- a/dev-docs/cli/CLAUDE.md
+++ b/dev-docs/cli/CLAUDE.md
@@ -2,6 +2,10 @@
 
 This file provides guidance to Claude Code when working with the Specify CLI in this repository.
 
+## Language Policy
+
+CLI-generated normative artifacts must be English-only. When generating templates or specifications, ensure all content is in English. Fail with a clear error if non-English content is detected in normative artifacts.
+
 ## Role
 
 You are responsible for developing and maintaining the Specify CLI tool that bootstraps SDD projects. Your focus areas include:

--- a/dev-docs/sdd/CLAUDE.md
+++ b/dev-docs/sdd/CLAUDE.md
@@ -2,6 +2,10 @@
 
 This file provides guidance to Claude Code when working with Spec-Driven Development workflows in this repository.
 
+## Language Policy
+
+All normative specification and task artifacts (PRDs, specifications, implementation plans, issues, task plans) committed to the repository MUST be written in English. Conversational discussions may occur in other languages, but do not commit non-English content to these artifacts.
+
 ## Role
 
 You are the primary AI developer and orchestrator for SDD workflows. Your responsibilities include:

--- a/memory/constitution.md
+++ b/memory/constitution.md
@@ -28,6 +28,9 @@
 [PRINCIPLE_5_DESCRIPTION]
 <!-- Example: Text I/O ensures debuggability; Structured logging required; Or: MAJOR.MINOR.BUILD format; Or: Start simple, YAGNI principles -->
 
+### VI. Language Policy (English-only Normative Artifacts)
+All normative specification and task artifacts committed to the repository (PRDs, specifications, implementation plans, issues, task plans) MUST be written in English. Conversational collaboration (discussions, PR comments, chat) may occur in other languages, but committed normative artifacts must remain English-only. This ensures global accessibility and consistency across all AI agents and contributors.
+
 ## [SECTION_2_NAME]
 <!-- Example: Additional Constraints, Security Requirements, Performance Standards, etc. -->
 

--- a/scripts/sdd/check_language.sh
+++ b/scripts/sdd/check_language.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# Language policy enforcement script
+# Checks that normative artifacts are written in English only
+
+set -euo pipefail
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Paths considered normative artifacts
+NORMATIVE_PATHS=("specs" "templates" "dev-docs" "memory")
+NORMATIVE_FILES=("CLAUDE.md" "AGENTS.md" "WARP.md")
+
+# Check for CJK characters (Chinese, Japanese, Korean) and Cyrillic
+# These are common non-English character ranges
+CJK_PATTERN='[\x{4E00}-\x{9FFF}\x{3040}-\x{30FF}\x{AC00}-\x{D7AF}\x{0400}-\x{04FF}]'
+
+FOUND_VIOLATIONS=0
+VIOLATION_FILES=""
+
+echo "🔍 Checking language policy compliance..."
+echo "   Normative artifacts must be written in English only"
+echo ""
+
+# Function to check a single file
+check_file() {
+    local file="$1"
+    
+    # Skip binary files and images
+    if file "$file" | grep -q "binary\|image\|data"; then
+        return 0
+    fi
+    
+    # Check for non-English characters (excluding code blocks)
+    if grep -qP "$CJK_PATTERN" "$file" 2>/dev/null; then
+        echo -e "${RED}✗${NC} Non-English characters found in: $file"
+        FOUND_VIOLATIONS=1
+        VIOLATION_FILES="$VIOLATION_FILES\n  - $file"
+        
+        # Show first occurrence with line number for debugging
+        if command -v grep &> /dev/null && grep --version | grep -q GNU; then
+            FIRST_LINE=$(grep -nP "$CJK_PATTERN" "$file" 2>/dev/null | head -1 | cut -d: -f1)
+            if [ -n "$FIRST_LINE" ]; then
+                echo "    First occurrence at line $FIRST_LINE"
+            fi
+        fi
+        return 1
+    fi
+    
+    return 0
+}
+
+# Check directories
+for dir in "${NORMATIVE_PATHS[@]}"; do
+    if [ -d "$dir" ]; then
+        echo "Checking directory: $dir/"
+        
+        # Find all markdown and text files
+        while IFS= read -r -d '' file; do
+            check_file "$file"
+        done < <(find "$dir" -type f \( -name "*.md" -o -name "*.txt" -o -name "*.rst" \) -print0 2>/dev/null)
+    fi
+done
+
+# Check root-level normative files
+for file in "${NORMATIVE_FILES[@]}"; do
+    if [ -f "$file" ]; then
+        echo "Checking file: $file"
+        check_file "$file"
+    fi
+done
+
+echo ""
+
+# Report results
+if [ $FOUND_VIOLATIONS -eq 1 ]; then
+    echo -e "${RED}═══════════════════════════════════════════════════════════${NC}"
+    echo -e "${RED}Language Policy Violation${NC}"
+    echo -e "${RED}═══════════════════════════════════════════════════════════${NC}"
+    echo ""
+    echo "Non-English characters were detected in normative artifacts."
+    echo "All specifications, plans, tasks, and documentation must be in English."
+    echo ""
+    echo -e "Files with violations:${VIOLATION_FILES}"
+    echo ""
+    echo "Please translate the content to English before committing."
+    echo -e "${RED}═══════════════════════════════════════════════════════════${NC}"
+    exit 1
+else
+    echo -e "${GREEN}✓${NC} All normative artifacts are in English"
+    echo -e "${GREEN}Language policy check passed!${NC}"
+    exit 0
+fi

--- a/templates/agent-file-template.md
+++ b/templates/agent-file-template.md
@@ -2,6 +2,10 @@
 
 Auto-generated from all feature plans. Last updated: [DATE]
 
+## Language Policy
+
+All normative specification and task artifacts (PRDs, specifications, implementation plans, issues, task plans) committed to the repository MUST be written in English. You may converse with developers in other languages, but do not commit non-English content to these artifacts.
+
 ## Active Technologies
 [EXTRACTED FROM ALL PLAN.MD FILES]
 

--- a/templates/commands/plan.md
+++ b/templates/commands/plan.md
@@ -9,6 +9,8 @@ This is the second step in the Spec-Driven Development lifecycle.
 
 Given the implementation details provided as an argument, do this:
 
+**Language Policy**: Produce the implementation plan in English only (all normative artifacts must be English).
+
 1. Run `scripts/setup-plan.sh --json` from the repo root and parse JSON for FEATURE_SPEC, IMPL_PLAN, SPECS_DIR, BRANCH. All future file paths must be absolute.
 2. Read and analyze the feature specification to understand:
    - The feature requirements and user stories

--- a/templates/commands/specify.md
+++ b/templates/commands/specify.md
@@ -9,6 +9,8 @@ This is the first step in the Spec-Driven Development lifecycle.
 
 Given the feature description provided as an argument, do this:
 
+**Language Policy**: Generate the specification in English only (all normative artifacts must be English).
+
 1. Run the script `scripts/create-new-feature.sh --json "{ARGS}"` from repo root and parse its JSON output for BRANCH_NAME and SPEC_FILE. All file paths must be absolute.
 2. Load `templates/spec-template.md` to understand required sections.
 3. Write the specification to SPEC_FILE using the template structure, replacing placeholders with concrete details derived from the feature description (arguments) while preserving section order and headings.

--- a/templates/commands/tasks.md
+++ b/templates/commands/tasks.md
@@ -9,6 +9,8 @@ This is the third step in the Spec-Driven Development lifecycle.
 
 Given the context provided as an argument, do this:
 
+**Language Policy**: Generate tasks.md in English only (all normative artifacts must be English).
+
 1. Run `scripts/check-task-prerequisites.sh --json` from repo root and parse FEATURE_DIR and AVAILABLE_DOCS list. All paths must be absolute.
 2. Load and analyze available design documents:
    - Always read plan.md for tech stack and libraries

--- a/templates/plan-template.md
+++ b/templates/plan-template.md
@@ -75,6 +75,9 @@
 - BUILD increments on every change?
 - Breaking changes handled? (parallel tests, migration plan)
 
+**Language Policy**:
+- All documentation artifacts (spec, plan, tasks, PRD, issues) written in English only?
+
 ## Project Structure
 
 ### Documentation (this feature)

--- a/templates/spec-template.md
+++ b/templates/spec-template.md
@@ -31,6 +31,7 @@
 - ✅ Focus on WHAT users need and WHY
 - ❌ Avoid HOW to implement (no tech stack, APIs, code structure)
 - 👥 Written for business stakeholders, not developers
+- 🌐 Written in English (all normative artifacts must be English-only)
 
 ### Section Requirements
 - **Mandatory sections**: Must be completed for every feature
@@ -88,6 +89,7 @@ When creating this spec from a user prompt:
 *GATE: Automated checks run during main() execution*
 
 ### Content Quality
+- [ ] Written in English (normative artifacts must be English-only)
 - [ ] No implementation details (languages, frameworks, APIs)
 - [ ] Focused on user value and business needs
 - [ ] Written for non-technical stakeholders

--- a/templates/tasks-template.md
+++ b/templates/tasks-template.md
@@ -119,6 +119,7 @@ Task: "Integration test auth in tests/integration/test_auth.py"
 ## Validation Checklist
 *GATE: Checked by main() before returning*
 
+- [ ] All task descriptions written in English (normative artifacts only)
 - [ ] All contracts have corresponding tests
 - [ ] All entities have model tasks
 - [ ] All tests come before implementation


### PR DESCRIPTION
## Summary

This PR implements the English-only language policy for all normative artifacts in the repository, ensuring global accessibility and consistency across all AI agents and contributors.

## Changes

### Core Policy Implementation
- ✅ Added Language Policy as Principle VI in `memory/constitution.md`
- ✅ Updated all SDD templates with language requirements and checklists:
  - `spec-template.md` - Added language guideline and checklist item
  - `plan-template.md` - Added language policy section
  - `tasks-template.md` - Added language validation
  - `agent-file-template.md` - Added language policy section

### AI Command Templates
- ✅ Added language policy directives to all command templates:
  - `templates/commands/specify.md`
  - `templates/commands/plan.md`  
  - `templates/commands/tasks.md`

### Agent Guidance
- ✅ Updated all agent context files with language policy:
  - Root `CLAUDE.md`
  - `dev-docs/sdd/CLAUDE.md`
  - `dev-docs/cli/CLAUDE.md`
  - `WARP.md`

### Validation Script
- ✅ Created `scripts/sdd/check_language.sh` for detecting non-English characters in normative artifacts

## Note on CI Integration

**CI workflow integration will be added in a separate PR after this is merged.** This is necessary because GitHub Actions security prevents modified workflows from running in the PR that modifies them.

## Testing

The language validation script has been tested locally:
```bash
./scripts/sdd/check_language.sh
# Output: ✓ All normative artifacts are in English
```

## Related Issues

- Addresses the language policy requirement discussed in our development session
- Split from PR #4 to avoid workflow validation issues

## Next Steps

After this PR is merged:
1. Create a follow-up PR to integrate the language check into CI workflows
2. Update existing documentation to comply with the English-only policy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新功能
  - 新增英文-only规范检测脚本，阻止非英语规范文档提交。
  - 规范/计划/任务生成流程强制英语输出；规范生成新增“完成报告”步骤。

- 文档
  - 统一“语言政策（规范性文档仅限英语）”。
  - 扩展测试与验证指引（pytest、SDD/语义/文档检查、CLI验证）。
  - 新增代码质量与依赖安装说明（格式化与Lint）。
  - 补充运行方式（含 uvx）、开发工作流脚本、目录结构与架构说明。
  - 各模板与指南加入英语校验清单与要求。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->