### PR TITLE
feat(ci): add language policy validation to CI workflow

### DIFF
--- a/.github/workflows/sdd-ci.yml
+++ b/.github/workflows/sdd-ci.yml
@@ -75,6 +75,23 @@ jobs:
             echo "Note: Python validation script not yet created"
           fi
 
+  language-policy:
+    name: Language Policy Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Validate English-only in normative artifacts
+        run: |
+          echo "Checking for non-English characters in normative artifacts..."
+          if [ -f "scripts/sdd/check_language.sh" ]; then
+            chmod +x scripts/sdd/check_language.sh
+            ./scripts/sdd/check_language.sh
+          else
+            echo "Warning: Language check script not found"
+          fi
+
   docs-style:
     name: Documentation Style Check
     runs-on: ubuntu-latest
@@ -219,13 +236,14 @@ jobs:
   summary:
     name: CI Summary
     runs-on: ubuntu-latest
-    needs: [sdd-validate, docs-style, tests, linters]
+    needs: [sdd-validate, language-policy, docs-style, tests, linters]
     if: always()
     steps:
       - name: Check job results
         run: |
           echo "## CI Summary"
           echo "- SDD Validation: ${{ needs.sdd-validate.result }}"
+          echo "- Language Policy: ${{ needs.language-policy.result }}"
           echo "- Documentation Style: ${{ needs.docs-style.result }}"
           echo "- Tests: ${{ needs.tests.result }}"
           echo "- Linters: ${{ needs.linters.result }}"


### PR DESCRIPTION
## Summary

This PR adds CI workflow integration for the language policy enforcement that was implemented in PR #5.

## Changes

### CI Workflow Integration
- ✅ Added `language-policy` job to `.github/workflows/sdd-ci.yml`
- ✅ Job executes the `scripts/sdd/check_language.sh` script
- ✅ Integrated language policy results into CI Summary
- ✅ Non-blocking during bootstrap phase (warnings only)

## Background

This is the follow-up PR to #5, which implemented the core language policy. The CI integration was separated to avoid GitHub Actions security restrictions that prevent modified workflows from running in the PR that modifies them.

## Testing

The language check script is already present and functional:
```bash
./scripts/sdd/check_language.sh
# Output: ✓ All normative artifacts are in English
```

## Notes

- The CI job will run on every push and pull request
- Currently non-blocking to allow for gradual migration
- Can be made blocking in the future by updating the summary check

## Related PRs

- #5 - Core language policy implementation (merged)
- #4 - Original combined PR (closed)