### PR TITLE
fix(security): add explicit permissions to all workflow jobs

### DIFF
--- a/.github/workflows/sdd-ci.yml
+++ b/.github/workflows/sdd-ci.yml
@@ -7,10 +7,16 @@ on:
     branches: [main]
   workflow_dispatch:
 
+# Default permissions for all jobs (can be overridden per job)
+permissions:
+  contents: read
+
 jobs:
   sdd-validate:
     name: Validate SDD Structure
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -78,6 +84,8 @@ jobs:
   language-policy:
     name: Language Policy Check
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -95,6 +103,8 @@ jobs:
   docs-style:
     name: Documentation Style Check
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -126,6 +136,8 @@ jobs:
   tests:
     name: Run Tests
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       matrix:
         python-version: ['3.11', '3.12']
@@ -163,6 +175,8 @@ jobs:
   linters:
     name: Code Quality
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -236,6 +250,8 @@ jobs:
   summary:
     name: CI Summary
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     needs: [sdd-validate, language-policy, docs-style, tests, linters]
     if: always()
     steps:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+This file provides AI Engineer guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
 ## Language Policy
 

--- a/WARP.md
+++ b/WARP.md
@@ -1,6 +1,6 @@
 # WARP.md
 
-This file provides guidance to Warp Agents (warp.dev) when working with code in this repository.
+This file provides AI Engineer guidance to Warp Agents (warp.dev) when working with code in this repository.
 
 ## Language Policy (English-only Normative Artifacts)
 


### PR DESCRIPTION
## 🔒 Security Fix: Workflow Permissions

### Problem
CodeQL detected 6 security warnings about missing workflow permissions in `.github/workflows/sdd-ci.yml`. Without explicit permissions, workflows use repository defaults which may grant unnecessary write access, violating the principle of least privilege.

### Solution
Added explicit `permissions: contents: read` to:
- ✅ Global workflow level (default for all jobs)
- ✅ `sdd-validate` job
- ✅ `language-policy` job  
- ✅ `docs-style` job
- ✅ `tests` job
- ✅ `linters` job
- ✅ `summary` job

The `ai-review` job already had proper permissions configured.

### Security Benefits
1. **Principle of Least Privilege**: Jobs only get the minimum permissions needed
2. **Prevents Accidental Writes**: No unintended modifications via GITHUB_TOKEN
3. **Compliance**: Follows GitHub Actions security best practices
4. **Clear Intent**: Explicit permissions make security posture obvious

### Testing
- All CI jobs will continue to function normally with read-only access
- The `ai-review` job retains its `pull-requests: write` permission for commenting
- No functional changes to workflow behavior

### References
- [GitHub Docs: Assigning permissions to jobs](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/assigning-permissions-to-jobs)
- CodeQL Alerts: #1, #2, #3, #4, #6, #7

---

**Security Impact**: 🟢 Low Risk - This change improves security by restricting permissions